### PR TITLE
Support custom image using registry url

### DIFF
--- a/deploy/lib/ensureKnativeService.js
+++ b/deploy/lib/ensureKnativeService.js
@@ -45,6 +45,9 @@ function ensureKnativeService(funcName) {
   if (registryAddress || registry) {
     Object.assign(inputs, { registryAddress: registryAddress || registry })
   }
+  if (funcObject.env) {
+    inputs.env = funcObject.env
+  }
   if (imagePullSecrets) {
     inputs.imagePullSecrets = imagePullSecrets
   }

--- a/deploy/lib/ensureKnativeService.js
+++ b/deploy/lib/ensureKnativeService.js
@@ -12,7 +12,7 @@ const {
 
 function ensureKnativeService(funcName) {
   const { service } = this.serverless.service
-  const { username, registry } = this.serverless.service.provider.docker
+  const { username, registry, imagePullSecrets } = this.serverless.service.provider.docker
 
   const ctx = new Context()
   const serving = new KnativeServing(undefined, ctx)
@@ -44,6 +44,9 @@ function ensureKnativeService(funcName) {
 
   if (registryAddress || registry) {
     Object.assign(inputs, { registryAddress: registryAddress || registry })
+  }
+  if (imagePullSecrets) {
+    inputs.imagePullSecrets = imagePullSecrets
   }
 
   this.serverless.cli.log(`Deploying Knative service for function "${inputs.name}"...`)

--- a/deploy/lib/ensureKnativeService.js
+++ b/deploy/lib/ensureKnativeService.js
@@ -21,11 +21,11 @@ function ensureKnativeService(funcName) {
   const name = getFuncName(service, funcName)
 
   let registryAddress
-  let repository = getRepository(username, name)
-  let tag = getTag(this.serverless.instanceId)
+  const funcObject = this.serverless.service.getFunction(funcName)
+  let repository = funcObject.image || getRepository(username, name)
+  let tag = getTag(this.serverless.instanceId, funcObject.tagPrefix)
 
   // see if we're re-using an existing image or if we need to reach out to our Container Registry
-  const funcObject = this.serverless.service.getFunction(funcName)
   if (isContainerImageUrl(funcObject.handler)) {
     const image = funcObject.handler
     const firstSlash = image.indexOf('/')

--- a/deploy/lib/ensureKnativeService.js
+++ b/deploy/lib/ensureKnativeService.js
@@ -12,7 +12,7 @@ const {
 
 function ensureKnativeService(funcName) {
   const { service } = this.serverless.service
-  const { username } = this.serverless.service.provider.docker
+  const { username, registry } = this.serverless.service.provider.docker
 
   const ctx = new Context()
   const serving = new KnativeServing(undefined, ctx)
@@ -42,8 +42,8 @@ function ensureKnativeService(funcName) {
     namespace
   }
 
-  if (registryAddress) {
-    Object.assign(inputs, { registryAddress })
+  if (registryAddress || registry) {
+    Object.assign(inputs, { registryAddress: registryAddress || registry })
   }
 
   this.serverless.cli.log(`Deploying Knative service for function "${inputs.name}"...`)

--- a/info/lib/displayInfo.js
+++ b/info/lib/displayInfo.js
@@ -23,7 +23,7 @@ function displayInfo() {
     message += `${chalk.yellow.underline('Service Information')}\n`
     message += `${chalk.yellow('service:')} ${service}\n`
     message += `${chalk.yellow('namespace:')} ${namespace}\n`
-    if (res.istioIngressIp.length > 0) {
+    if (res.istioIngressIp && res.istioIngressIp.length > 0) {
       message += `${chalk.yellow('ingress ip:')} ${res.istioIngressIp}\n`
     }
 

--- a/package/lib/buildDockerImage.js
+++ b/package/lib/buildDockerImage.js
@@ -9,7 +9,7 @@ function buildDockerImage(funcName) {
   const { service } = this.serverless.service
   const funcObj = this.serverless.service.getFunction(funcName)
   const buildContext = funcObj.context || process.cwd
-  const { username } = this.serverless.service.provider.docker
+  const { username, registry = '' } = this.serverless.service.provider.docker
   const name = getFuncName(service, funcName)
 
   const ctx = new Context()
@@ -17,7 +17,7 @@ function buildDockerImage(funcName) {
 
   const context = path.resolve(buildContext)
   const dockerfile = funcObj.handler
-  const repository = funcObj.image || getRepository(username, name)
+  const repository = funcObj.image ? [registry, funcObj.image].join('/') : getRepository(username, name)
   const tag = getTag(this.serverless.instanceId, funcObj.tagPrefix)
 
   const inputs = {

--- a/package/lib/buildDockerImage.js
+++ b/package/lib/buildDockerImage.js
@@ -17,8 +17,8 @@ function buildDockerImage(funcName) {
 
   const context = path.resolve(buildContext)
   const dockerfile = funcObj.handler
-  const repository = getRepository(username, name)
-  const tag = getTag(this.serverless.instanceId)
+  const repository = funcObj.image || getRepository(username, name)
+  const tag = getTag(this.serverless.instanceId, funcObj.tagPrefix)
 
   const inputs = {
     context,

--- a/package/lib/pushDockerImage.js
+++ b/package/lib/pushDockerImage.js
@@ -7,7 +7,7 @@ const { getFuncName, getTag, getRepository } = require('../../shared/utils')
 function pushDockerImage(funcName) {
   const { service } = this.serverless.service
   const name = getFuncName(service, funcName)
-  const { username } = this.serverless.service.provider.docker
+  const { username, registry = '' } = this.serverless.service.provider.docker
   const { password } = this.serverless.service.provider.docker
   const credentials = {
     docker: {
@@ -22,7 +22,7 @@ function pushDockerImage(funcName) {
   dockerImage.context.credentials = credentials
 
   const { image, tagPrefix } = this.serverless.service.getFunction(funcName)
-  const repository = image || getRepository(username, name)
+  const repository = image ? [registry, image].join('/') : getRepository(username, name)
   const tag = getTag(this.serverless.instanceId, tagPrefix)
 
   const inputs = {

--- a/package/lib/pushDockerImage.js
+++ b/package/lib/pushDockerImage.js
@@ -21,8 +21,9 @@ function pushDockerImage(funcName) {
   // manually setting the credentials of the child-component here
   dockerImage.context.credentials = credentials
 
-  const repository = getRepository(username, name)
-  const tag = getTag(this.serverless.instanceId)
+  const { image, tagPrefix } = this.serverless.service.getFunction(funcName)
+  const repository = image || getRepository(username, name)
+  const tag = getTag(this.serverless.instanceId, tagPrefix)
 
   const inputs = {
     repository,

--- a/remove/lib/removeDockerImage.js
+++ b/remove/lib/removeDockerImage.js
@@ -16,8 +16,8 @@ function removeDockerImage(funcName) {
 
   const context = process.cwd()
   const dockerfile = funcObj.handler
-  const repository = getRepository(username, name)
-  const tag = getTag(this.serverless.instanceId)
+  const repository = funcObj.image || getRepository(username, name)
+  const tag = getTag(this.serverless.instanceId, funcObj.tagPrefix)
 
   const inputs = {
     context,

--- a/remove/lib/removeDockerImage.js
+++ b/remove/lib/removeDockerImage.js
@@ -8,7 +8,7 @@ const { getFuncName, getTag, getRepository } = require('../../shared/utils')
 function removeDockerImage(funcName) {
   const { service } = this.serverless.service
   const funcObj = this.serverless.service.getFunction(funcName)
-  const { username } = this.serverless.service.provider.docker
+  const { username, registry = '' } = this.serverless.service.provider.docker
   const name = getFuncName(service, funcName)
 
   const ctx = new Context()
@@ -16,7 +16,7 @@ function removeDockerImage(funcName) {
 
   const context = process.cwd()
   const dockerfile = funcObj.handler
-  const repository = funcObj.image || getRepository(username, name)
+  const repository = funcObj.image ? [registry, funcObj.image].join('/') : getRepository(username, name)
   const tag = getTag(this.serverless.instanceId, funcObj.tagPrefix)
 
   const inputs = {

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -18,8 +18,8 @@ function getRepository(username, name) {
   return `${username}/${name}`.toLowerCase()
 }
 
-function getTag(tag = 'latest') {
-  return tag
+function getTag(tag = 'latest', prefix = '') {
+  return [prefix, tag].join('')
 }
 
 function getFuncName(service, funcName) {


### PR DESCRIPTION
- [x] add `registry` key
- [x] add `imagePullSecrets` key
- [x] add `image` key
- [x] add `tagPrefix` key
- [x] add `env` key

```
provider:
  docker:
    registry: registry.gitlab.com
    imagePullSecrets:
      - name: 'image-pull-secret'
    ...
```

in handler, specifying env will be copied into `spec.template.spec.containers[]`

```
functions:
  hello:
    handler: Dockerfile.hello
    image: kennyhyun/container
    tagPrefix: knative-hello-
    env:
      - name: TARGET
         value: stage
    ...
```
using `registry.gitlab.com/kennyhyun/container:knative-hello-123456789` as a image url

`imagePullSecrets` is just passed to knative-serving, which is not supported.

So, this requires
https://github.com/kennyhyun/knative-serving/pull/2 
as well

checked working in 

knative-serving [v1.8.3](/kennyhyun/knative-serving/pull/2)
serverless framework 3.38.0

![image](https://github.com/kennyhyun/serverless-knative/assets/5399854/da66e8b4-c143-41f2-84f5-9f21a9686ebe)

```
$ kubectl get ksvc -A
NAMESPACE         NAME            URL                                                 LATESTCREATED         LATESTREADY           READY   REASON
default           hello           http://hello.default.mydomain.net                   hello-00002           hello-00002           True
sls-knative-dev   knative-hello   http://knative-hello.sls-knative-dev.mydomain.net   knative-hello-00012   knative-hello-00012   True
$ http --verify=no https://knative-hello.sls-knative-dev.mydomain.net
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 12
Content-Type: text/html; charset=utf-8
Date: Thu, 18 Jan 2024 13:53:41 GMT
Strict-Transport-Security: max-age=15724800; includeSubDomains
x-envoy-upstream-service-time: 1912

Hello World
```

had to have kourier and ingress for that as well